### PR TITLE
Fix typo in footer component

### DIFF
--- a/src/components/layout/Footer.js
+++ b/src/components/layout/Footer.js
@@ -89,7 +89,7 @@ const Footer = ({ path }) => {
         </a>{' '}
         or submit a PR or issue on{' '}
         <a href="https://github.com/jacobdcastro/personal-site/" rel="noopener">
-          the Gtihub repo
+          the Github repo
         </a>
         !
       </span>


### PR DESCRIPTION
`Github` was mispelled as `Gtihub`