### PR TITLE
Add About me page as a galaxy planet

### DIFF
--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -6,13 +6,18 @@
     <priority>1.0</priority>
   </url>
   <url>
+    <loc>https://jacobdcastro.com/about</loc>
+    <changefreq>monthly</changefreq>
+    <priority>0.9</priority>
+  </url>
+  <url>
     <loc>https://jacobdcastro.com/blog</loc>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://jacobdcastro.com/blog/chain-abstraction-thoughts</loc>
-    <lastmod>Sun Aug 11 2024 17:00:00 GMT-0700 (Pacific Daylight Time)</lastmod>
+    <lastmod>Mon Aug 12 2024 00:00:00 GMT+0000 (Coordinated Universal Time)</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.7</priority>
   </url>

--- a/scripts/generate-seo-files.ts
+++ b/scripts/generate-seo-files.ts
@@ -44,6 +44,7 @@ function xmlEscape(value: string) {
 function buildSitemap(posts: PostFrontmatter[]) {
 	const urls = [
 		{ loc: `${SITE_URL}/`, changefreq: "monthly", priority: "1.0" },
+		{ loc: `${SITE_URL}/about`, changefreq: "monthly", priority: "0.9" },
 		{ loc: `${SITE_URL}/blog`, changefreq: "weekly", priority: "0.8" },
 		...posts.map((post) => ({
 			loc: `${SITE_URL}/blog/${post.slug}`,

--- a/src/components/galaxy/GalaxyLinkLabels.tsx
+++ b/src/components/galaxy/GalaxyLinkLabels.tsx
@@ -1,5 +1,7 @@
 import { useEffect, useRef, type RefObject } from "react";
+import { useNavigate } from "@tanstack/react-router";
 import type { GalaxyLink } from "../../data/links";
+import { isPageLink } from "../../lib/galaxy-link-action";
 import {
 	linkRadiusCells,
 	type ProjectedLink,
@@ -36,6 +38,7 @@ export function GalaxyLinkLabels({
 	const containerRef = useRef<HTMLDivElement>(null);
 	const markerRefs = useRef(new Map<string, HTMLDivElement>());
 	const smoothRef = useRef(new Map<string, SmoothedLink>());
+	const navigate = useNavigate();
 	const setHovered = useNavStore((s) => s.setHovered);
 	const setFocusedLink = useNavStore((s) => s.setFocusedLink);
 
@@ -136,6 +139,11 @@ export function GalaxyLinkLabels({
 	}, [active, links, projectedRef]);
 
 	function selectLink(link: GalaxyLink) {
+		if (isPageLink(link)) {
+			navigate({ to: link.href });
+			return;
+		}
+
 		const current = useNavStore.getState().focusedLinkId;
 		if (current === link.id) {
 			if (!canDismissZoomLock()) return;

--- a/src/components/galaxy/LinkStars.tsx
+++ b/src/components/galaxy/LinkStars.tsx
@@ -7,7 +7,9 @@ import {
 	type MeshBasicMaterial,
 	Vector3,
 } from "three";
+import { useNavigate } from "@tanstack/react-router";
 import type { GalaxyLink } from "../../data/links";
+import { isPageLink } from "../../lib/galaxy-link-action";
 import { getLinkLocalPosition } from "../../lib/galaxy-simulation";
 import { prefersReducedMotion } from "../../lib/input-device";
 import {
@@ -49,6 +51,7 @@ interface LinkStarProps {
 }
 
 function LinkStar({ entry, onMeshRef, onLabelRef, isFocused }: LinkStarProps) {
+	const navigate = useNavigate();
 	const setHovered = useNavStore((s) => s.setHovered);
 	const setFocusedLink = useNavStore((s) => s.setFocusedLink);
 
@@ -69,6 +72,11 @@ function LinkStar({ entry, onMeshRef, onLabelRef, isFocused }: LinkStarProps) {
 	}
 
 	function selectLink() {
+		if (isPageLink(entry.link)) {
+			navigate({ to: entry.link.href });
+			return;
+		}
+
 		const current = useNavStore.getState().focusedLinkId;
 		if (current === entry.link.id) {
 			if (!canDismissZoomLock()) return;

--- a/src/content/about.ts
+++ b/src/content/about.ts
@@ -1,0 +1,8 @@
+export const ABOUT_PAGE = {
+	title: "About me",
+	paragraphs: [
+		"Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.",
+		"Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.",
+		"Curabitur pretium tincidunt lacus. Nulla facilisi. Ut fringilla. Suspendisse potenti. Nunc feugiat mi a tellus consequat imperdiet. Vestibulum sapien proin quam etiam ultrices.",
+	],
+} as const;

--- a/src/data/links.ts
+++ b/src/data/links.ts
@@ -3,6 +3,8 @@ export interface GalaxyLink {
   label: string;
   href: string;
   description: string;
+  /** internal route — tap navigates to a full page instead of zoom + detail panel */
+  page?: boolean;
   /** spiral arm index (0 … branches-1) */
   branch: number;
   /** distance from galactic center */
@@ -20,6 +22,15 @@ export const LINKS: GalaxyLink[] = [
     description: "My code... obviously.",
     branch: 2,
     radius: 2.7,
+  },
+  {
+    id: "about",
+    label: "About me",
+    href: "/about",
+    description: "The human behind the stars.",
+    page: true,
+    branch: 3,
+    radius: 2.15,
   },
   {
     id: "resume",

--- a/src/hooks/useGalaxyInput.ts
+++ b/src/hooks/useGalaxyInput.ts
@@ -1,5 +1,8 @@
+import { useNavigate } from "@tanstack/react-router";
 import type { PointerEvent as ReactPointerEvent } from "react";
 import { type RefObject, useEffect, useRef } from "react";
+import { LINKS } from "../data/links";
+import { isPageLink } from "../lib/galaxy-link-action";
 import { canDismissZoomLock } from "../lib/zoom-focus-state";
 import { useNavStore } from "../store/nav-store";
 
@@ -38,6 +41,7 @@ export function useGalaxyInput({
 	velocity,
 	resolveTapLink,
 }: UseGalaxyInputOptions) {
+	const navigate = useNavigate();
 	const containerRef = useRef<HTMLDivElement>(null);
 	const lastPointer = useRef({ x: 0, y: 0 });
 	const dragMoved = useRef(0);
@@ -127,6 +131,12 @@ export function useGalaxyInput({
 			resolveTapLinkRef.current?.(clientX, clientY) ??
 			null;
 		if (!linkId) return;
+
+		const link = LINKS.find((entry) => entry.id === linkId);
+		if (link && isPageLink(link)) {
+			navigate({ to: link.href });
+			return;
+		}
 
 		const current = useNavStore.getState().focusedLinkId;
 		if (current === linkId) {

--- a/src/lib/galaxy-link-action.ts
+++ b/src/lib/galaxy-link-action.ts
@@ -1,0 +1,5 @@
+import type { GalaxyLink } from "../data/links";
+
+export function isPageLink(link: GalaxyLink) {
+	return link.page === true;
+}

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -10,12 +10,18 @@
 
 import { Route as rootRouteImport } from './routes/__root'
 import { Route as IndexRouteImport } from './routes/index'
+import { Route as AboutRouteImport } from './routes/about'
 import { Route as BlogIndexRouteImport } from './routes/blog/index'
 import { Route as BlogSlugRouteImport } from './routes/blog/$slug'
 
 const IndexRoute = IndexRouteImport.update({
   id: '/',
   path: '/',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const AboutRoute = AboutRouteImport.update({
+  id: '/about',
+  path: '/about',
   getParentRoute: () => rootRouteImport,
 } as any)
 const BlogIndexRoute = BlogIndexRouteImport.update({
@@ -31,30 +37,34 @@ const BlogSlugRoute = BlogSlugRouteImport.update({
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
+  '/about': typeof AboutRoute
   '/blog/$slug': typeof BlogSlugRoute
   '/blog/': typeof BlogIndexRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
+  '/about': typeof AboutRoute
   '/blog/$slug': typeof BlogSlugRoute
   '/blog': typeof BlogIndexRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
+  '/about': typeof AboutRoute
   '/blog/$slug': typeof BlogSlugRoute
   '/blog/': typeof BlogIndexRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
-  fullPaths: '/' | '/blog/$slug' | '/blog/'
+  fullPaths: '/' | '/about' | '/blog/$slug' | '/blog/'
   fileRoutesByTo: FileRoutesByTo
-  to: '/' | '/blog/$slug' | '/blog'
-  id: '__root__' | '/' | '/blog/$slug' | '/blog/'
+  to: '/' | '/about' | '/blog/$slug' | '/blog'
+  id: '__root__' | '/' | '/about' | '/blog/$slug' | '/blog/'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
+  AboutRoute: typeof AboutRoute
   BlogSlugRoute: typeof BlogSlugRoute
   BlogIndexRoute: typeof BlogIndexRoute
 }
@@ -66,6 +76,13 @@ declare module '@tanstack/react-router' {
       path: '/'
       fullPath: '/'
       preLoaderRoute: typeof IndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/about': {
+      id: '/about'
+      path: '/about'
+      fullPath: '/about'
+      preLoaderRoute: typeof AboutRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/blog/': {
@@ -87,6 +104,7 @@ declare module '@tanstack/react-router' {
 
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
+  AboutRoute: AboutRoute,
   BlogSlugRoute: BlogSlugRoute,
   BlogIndexRoute: BlogIndexRoute,
 }

--- a/src/routes/about.tsx
+++ b/src/routes/about.tsx
@@ -1,0 +1,42 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { JsonLd } from "../components/seo/JsonLd";
+import { ABOUT_PAGE } from "../content/about";
+import { buildPageHead } from "../lib/seo";
+import { SITE } from "../lib/site";
+
+export const Route = createFileRoute("/about")({
+	head: () =>
+		buildPageHead({
+			title: ABOUT_PAGE.title,
+			description:
+				"About Jacob D. Castro — fullstack software engineer, founder, and product-minded builder.",
+			path: "/about",
+		}),
+	component: AboutPage,
+});
+
+function AboutPage() {
+	return (
+		<article className="mx-auto max-w-3xl px-6 py-12">
+			<JsonLd
+				data={{
+					"@context": "https://schema.org",
+					"@type": "ProfilePage",
+					name: ABOUT_PAGE.title,
+					url: `${SITE.url}/about`,
+					mainEntity: {
+						"@type": "Person",
+						name: SITE.author,
+						url: SITE.url,
+					},
+				}}
+			/>
+			<h1 className="text-4xl font-bold">{ABOUT_PAGE.title}</h1>
+			<div className="prose prose-invert mt-8 max-w-none">
+				{ABOUT_PAGE.paragraphs.map((paragraph) => (
+					<p key={paragraph}>{paragraph}</p>
+				))}
+			</div>
+		</article>
+	);
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Adds `/about` with placeholder lorem ipsum content styled like the blog (Computer Modern serif, `prose prose-invert`, `max-w-3xl` layout).
- Adds an **About me** star to the galaxy navigation.
- Page links (`page: true`) navigate directly to their route on tap instead of opening the zoom + detail panel flow.

## Editing content later

Update `src/content/about.ts` — title and paragraph array. No route or component changes needed.

## Test plan

- [x] `npm run test` passes
- [x] `vite build` succeeds
- [ ] Click **About me** in galaxy (3D) → navigates to `/about`
- [ ] Click **About me** in list mode → navigates to `/about`
- [ ] `/about` shows title and three lorem ipsum paragraphs in serif typography
- [ ] Site name link in header returns to galaxy home
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a030a9-d11c-73bc-bf95-25537b36468a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a030a9-d11c-73bc-bf95-25537b36468a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

